### PR TITLE
Add license information to console web / app (lablup/backend.ai#170)

### DIFF
--- a/console-server.sample.conf
+++ b/console-server.sample.conf
@@ -37,5 +37,9 @@ redis.port = 6379
 # redis.password = "mysecret"
 max_age = 2592000  # 30 days
 flush_on_startup = false
+#[license]
+#edition = "Open Source"
+#valid_since = ""
+#valid_until = ""
 
 # vim: ft=toml

--- a/console-server.sample.conf
+++ b/console-server.sample.conf
@@ -37,6 +37,8 @@ redis.port = 6379
 # redis.password = "mysecret"
 max_age = 2592000  # 30 days
 flush_on_startup = false
+
+# Add a manually configured license information shown in the UI.
 #[license]
 #edition = "Open Source"
 #valid_since = ""

--- a/src/ai/backend/console/server.py
+++ b/src/ai/backend/console/server.py
@@ -121,7 +121,7 @@ async def console_handler(request: web.Request) -> web.StreamResponse:
                 'true' if config['service']['allow_project_resource_monitor'] else 'false',
             'license_edition': license_edition if license_edition is not None else 'Open Source',
             'license_valid_since': license_valid_since if license_valid_since is not None else '',
-            'license_valid_until': license_valid_until if license_valid_until is not None else ''
+            'license_valid_until': license_valid_until if license_valid_until is not None else '',
         })
         return web.Response(text=config_content)
     # SECURITY: only allow reading files under static_path

--- a/src/ai/backend/console/server.py
+++ b/src/ai/backend/console/server.py
@@ -64,6 +64,11 @@ allowProjectResourceMonitor  = {{allow_project_resource_monitor}}
 proxyURL = "{{proxy_url}}/"
 #proxyBaseURL =
 #proxyListenIP =
+
+[license]
+edition = "{{license_edition}}"
+validSince = "{{license_valid_since}}"
+validUntil = "{{license_valid_until}}"
 ''')
 
 
@@ -103,6 +108,9 @@ async def console_handler(request: web.Request) -> web.StreamResponse:
         return web.Response(text=config_content)
 
     if request_path == 'config.toml':
+        license_edition = config['license'].get('edition')
+        license_valid_since = config['license'].get('valid_since')
+        license_valid_until = config['license'].get('valid_until')
         config_content = console_config_toml_template.render(**{
             'endpoint_url': f'{scheme}://{request.host}',  # must be absolute
             'endpoint_text': config['api']['text'],
@@ -110,7 +118,10 @@ async def console_handler(request: web.Request) -> web.StreamResponse:
             'proxy_url': config['service']['wsproxy']['url'],
             'signup_support': 'true' if config['service']['enable_signup'] else 'false',
             'allow_project_resource_monitor':
-                'true' if config['service']['allow_project_resource_monitor'] else 'false'
+                'true' if config['service']['allow_project_resource_monitor'] else 'false',
+            'license_edition': license_edition if license_edition is not None else 'Open Source',
+            'license_valid_since': license_valid_since if license_valid_since is not None else '',
+            'license_valid_until': license_valid_until if license_valid_until is not None else ''
         })
         return web.Response(text=config_content)
     # SECURITY: only allow reading files under static_path


### PR DESCRIPTION
This PR resolves lablup/backend.ai#170

In addition to using the API to parse license information from the server and pass it to the client through the API, it also provides a way to force different information to app or web service through a separate console config (toml).