### PR TITLE
feat: add option to set default session environment

### DIFF
--- a/console-server.sample.conf
+++ b/console-server.sample.conf
@@ -23,6 +23,7 @@ allow_project_resource_monitor = false
 
 [ui]
 brand = "Lablup Cloud"
+# default_environment = 'index.docker.io/lablup/python-tensorflow'
 
 [api]
 domain = "default"

--- a/src/ai/backend/console/server.py
+++ b/src/ai/backend/console/server.py
@@ -41,7 +41,9 @@ assert static_path.is_dir()
 console_config_ini_template = jinja2.Template('''[general]
 apiEndpoint = {{endpoint_url}}
 apiEndpointText = {{endpoint_text}}
-defaultSessionEnvironment =
+{% if default_environment %}
+defaultSessionEnvironment = "{{default_environment}}"
+{% endif %}
 siteDescription = {{site_description}}
 connectionMode = "SESSION"
 
@@ -54,7 +56,9 @@ proxyListenIP =
 console_config_toml_template = jinja2.Template('''[general]
 apiEndpoint = "{{endpoint_url}}"
 apiEndpointText = "{{endpoint_text}}"
-#defaultSessionEnvironment =
+{% if default_environment %}
+defaultSessionEnvironment = "{{default_environment}}"
+{% endif %}
 siteDescription = "{{site_description}}"
 connectionMode = "SESSION"
 signupSupport = {{signup_support}}
@@ -103,6 +107,7 @@ async def console_handler(request: web.Request) -> web.StreamResponse:
             'endpoint_url': f'{scheme}://{request.host}',  # must be absolute
             'endpoint_text': config['api']['text'],
             'site_description': config['ui']['brand'],
+            'default_environment': config['ui'].get('default_environment'),
             'proxy_url': config['service']['wsproxy']['url'],
         })
         return web.Response(text=config_content)
@@ -115,6 +120,7 @@ async def console_handler(request: web.Request) -> web.StreamResponse:
             'endpoint_url': f'{scheme}://{request.host}',  # must be absolute
             'endpoint_text': config['api']['text'],
             'site_description': config['ui']['brand'],
+            'default_environment': config['ui'].get('default_environment'),
             'proxy_url': config['service']['wsproxy']['url'],
             'signup_support': 'true' if config['service']['enable_signup'] else 'false',
             'allow_project_resource_monitor':


### PR DESCRIPTION
It seems there is no way to set the default session environment, such as `index.docker.io/lablup/python-tensorflow`. This pull-request adds `default_environment` option in `[ui]` section of `console-server.conf`.