### PR TITLE
feat: expose allow change signin mode option

### DIFF
--- a/changes/12.feature
+++ b/changes/12.feature
@@ -1,0 +1,1 @@
+Add option to expose `allow change signin mode` option by config.toml

--- a/changes/template.md
+++ b/changes/template.md
@@ -1,0 +1,38 @@
+{%- for section, _ in sections.items() -%}
+  {%- if section %}
+### {{ section }}
+  {%- endif -%}
+  {%- if sections[section] -%}
+    {%- for category, val in definitions.items() if category in sections[section] %}
+
+
+#### {{ definitions[category]['name'] }}
+
+      {%- if definitions[category]['showcontent'] %}
+        {%- for text, values in sections[section][category].items() %}
+          {%- if values[0].endswith("/0)") %}
+
+* {{ definitions[category]['name'] }} without explicit PR/issue numbers
+  {{ text }}
+          {%- else %}
+
+* {{ text }} {{ values|join(',\n  ') }}
+          {%- endif %}
+
+        {%- endfor %}
+      {%- else %}
+
+* {{ sections[section][category]['']|join(', ') }}
+      {%- endif %}
+      {%- if sections[section][category]|length == 0 %}
+
+No significant changes.
+      {%- else %}
+      {%- endif %}
+
+    {%- endfor %}
+    {%- else %}
+
+No significant changes.
+  {%- endif %}
+{%- endfor %}

--- a/console-server.sample.conf
+++ b/console-server.sample.conf
@@ -19,7 +19,10 @@ wsproxy.url = ""
 mode = "webconsole"
 # Enable signup feature support.
 enable_signup = false
+# Allow users to see user's current project resource monitor
 allow_project_resource_monitor = false
+# Allow users to change signin mode between ID/Password and IAM mode
+allow_change_signin_mode = false
 
 [ui]
 brand = "Lablup Cloud"

--- a/src/ai/backend/console/server.py
+++ b/src/ai/backend/console/server.py
@@ -124,7 +124,7 @@ async def console_handler(request: web.Request) -> web.StreamResponse:
             'default_environment': config['ui'].get('default_environment'),
             'proxy_url': config['service']['wsproxy']['url'],
             'signup_support': 'true' if config['service']['enable_signup'] else 'false',
-            'allow_change_signin_mode': 
+            'allow_change_signin_mode':
                 'true' if config['service'].get('allow_change_signin_mode') else 'false',
             'allow_project_resource_monitor':
                 'true' if config['service']['allow_project_resource_monitor'] else 'false',

--- a/src/ai/backend/console/server.py
+++ b/src/ai/backend/console/server.py
@@ -62,6 +62,7 @@ defaultSessionEnvironment = "{{default_environment}}"
 siteDescription = "{{site_description}}"
 connectionMode = "SESSION"
 signupSupport = {{signup_support}}
+allowChangeSigninMode = {{allow_change_signin_mode}}
 allowProjectResourceMonitor  = {{allow_project_resource_monitor}}
 
 [wsproxy]
@@ -123,6 +124,7 @@ async def console_handler(request: web.Request) -> web.StreamResponse:
             'default_environment': config['ui'].get('default_environment'),
             'proxy_url': config['service']['wsproxy']['url'],
             'signup_support': 'true' if config['service']['enable_signup'] else 'false',
+            'allow_change_signin_mode': 'true' if config['service'].get('allow_change_signin_mode') else 'false',
             'allow_project_resource_monitor':
                 'true' if config['service']['allow_project_resource_monitor'] else 'false',
             'license_edition': license_edition if license_edition is not None else 'Open Source',

--- a/src/ai/backend/console/server.py
+++ b/src/ai/backend/console/server.py
@@ -124,7 +124,8 @@ async def console_handler(request: web.Request) -> web.StreamResponse:
             'default_environment': config['ui'].get('default_environment'),
             'proxy_url': config['service']['wsproxy']['url'],
             'signup_support': 'true' if config['service']['enable_signup'] else 'false',
-            'allow_change_signin_mode': 'true' if config['service'].get('allow_change_signin_mode') else 'false',
+            'allow_change_signin_mode': 
+                'true' if config['service'].get('allow_change_signin_mode') else 'false',
             'allow_project_resource_monitor':
                 'true' if config['service']['allow_project_resource_monitor'] else 'false',
             'license_edition': license_edition if license_edition is not None else 'Open Source',


### PR DESCRIPTION
This PR resolves part of lablup/backend.ai-console#479


 * Login sometimes changes to IAM and not returned
 * If `allowChangeSigninMode = false`, there is no way to change back to E-mail login

## Reason

The API login mode is the initial value when determining the login mode before the load of the configuration file ends. The result is cached by the change of # 276, and since the value is saved in the localCache, it is fixed as API mode even when the server sends the login mode to SESSION.


## Solution (solved in console)

 * [x] Only use the last login option in app mode
 * [x] Change default to SESSION
 * [x] Force use default login mode from config.toml when using web mode

## Solution (in console server, this PR)
 * [ ] Expose allowChangeSigninMode option from console server
