### PR TITLE
fix: specify no-store only to disable cache for static files

### DIFF
--- a/changes/21.fix
+++ b/changes/21.fix
@@ -1,0 +1,1 @@
+Specify no-store only to disable cache for static files.

--- a/src/ai/backend/console/server.py
+++ b/src/ai/backend/console/server.py
@@ -156,10 +156,10 @@ async def console_handler(request: web.Request) -> web.StreamResponse:
 
 cache_patterns = {
     r'\.(?:manifest|appcache|html?|xml|json|ini|toml)$': {
-        'Cache-Control': 'no-cache, no-store, must-revalidate'
+        'Cache-Control': 'no-store'
     },
     r'(?:backend.ai-console.js)$': {
-        'Cache-Control': 'no-cache, no-store, must-revalidate'
+        'Cache-Control': 'no-store'
     },
     r'\.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc|woff|woff2)$': {
         'Cache-Control': 'max-age=259200, public',
@@ -168,7 +168,7 @@ cache_patterns = {
         'Cache-Control': 'max-age=86400, public, must-revalidate, proxy-revalidate',
     },
     r'\.(?:py|log?|txt)$': {
-        'Cache-Control': 'no-cache, no-store, must-revalidate'
+        'Cache-Control': 'no-store'
     },
 }
 _cache_patterns = {re.compile(k): v for k, v in cache_patterns.items()}


### PR DESCRIPTION
According to the MDN documentation, `no-store` is enough to disable resource caching.

> `no-store`
The response may not be stored in any cache. Although other directives may be set, this alone is the only directive you need in preventing cached responses on modern browsers. max-age=0 is already implied. Setting must-revalidate does not make sense because in order to go through revalidation you need the response to be stored in a cache, which no-store prevents.

The doc also presents clear example on this:
![image](https://user-images.githubusercontent.com/7539358/92868652-eaa33100-f43c-11ea-9b23-b4f5db4ae6ba.png)

Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control