### PR TITLE
feat: add option to enable/disable open port to public checkbox

### DIFF
--- a/changes/22.feature
+++ b/changes/22.feature
@@ -1,0 +1,1 @@
+Add option to enable/disable open port to public checkbox.

--- a/console-server.sample.conf
+++ b/console-server.sample.conf
@@ -25,6 +25,9 @@ allow_anonymous_change_password = false
 allow_project_resource_monitor = false
 # Allow users to change signin mode between ID/Password and IAM mode
 allow_change_signin_mode = false
+# Display "Open port to public" checkbox in the app launcher.
+# If checked, the app will be accessible by anyone who has network to the URL.
+open_port_to_public = false
 
 [ui]
 brand = "Lablup Cloud"

--- a/src/ai/backend/console/server.py
+++ b/src/ai/backend/console/server.py
@@ -64,7 +64,8 @@ connectionMode = "SESSION"
 signupSupport = {{signup_support}}
 allowChangeSigninMode = {{allow_change_signin_mode}}
 allowAnonymousChangePassword = {{allow_anonymous_change_password}}
-allowProjectResourceMonitor  = {{allow_project_resource_monitor}}
+allowProjectResourceMonitor = {{allow_project_resource_monitor}}
+openPortToPublic = {{open_port_to_public}}
 
 [menu]
 blocklist = "{{menu_blocklist}}"
@@ -134,6 +135,8 @@ async def console_handler(request: web.Request) -> web.StreamResponse:
                 'true' if config['service'].get('allow_anonymous_change_password') else 'false',
             'allow_project_resource_monitor':
                 'true' if config['service']['allow_project_resource_monitor'] else 'false',
+            'open_port_to_public':
+                'true' if config['service']['open_port_to_public'] else 'false',
             'menu_blocklist': config['ui'].get('menu_blocklist', ''),
             'license_edition': license_edition,
             'license_valid_since': license_valid_since,


### PR DESCRIPTION
This PR adds an option to enable/disable "Open port to public" checkbox.

Related: https://github.com/lablup/backend.ai-console/pull/751
Internal ticket: OP#838