### PR TITLE
feat: use persistent manager endpoint for websocket streaming (app) per session and per app

### DIFF
--- a/changes/30.fix
+++ b/changes/30.fix
@@ -1,0 +1,1 @@
+Use persistent manager endpoint for websocket streaming (app) per session and per app by storing the endpoint information in the browser session.

--- a/console-server.sample.conf
+++ b/console-server.sample.conf
@@ -53,6 +53,7 @@ brand = "Lablup Cloud"
 [api]
 domain = "default"
 endpoint = "https://api.backend.ai"
+# endpoint = "https://api.backend.ai,https://alt.backend.ai"  # for HA manager endpoints
 text = "Backend.AI Cloud"
 ssl-verify = true
 

--- a/src/ai/backend/console/auth.py
+++ b/src/ai/backend/console/auth.py
@@ -1,3 +1,4 @@
+import copy
 import json
 
 from aiohttp import web
@@ -9,8 +10,14 @@ from ai.backend.client.config import APIConfig
 from . import user_agent
 
 
-async def get_api_session(request: web.Request) -> APISession:
+async def get_api_session(
+    request: web.Request,
+    api_endpoint: str = None,
+) -> APISession:
     config = request.app['config']
+    if api_endpoint is not None:
+        config = copy.deepcopy(config)
+        config['api']['endpoint'] = api_endpoint
     session = await get_session(request)
     if not session.get('authenticated', False):
         raise web.HTTPUnauthorized(text=json.dumps({
@@ -40,8 +47,14 @@ async def get_api_session(request: web.Request) -> APISession:
     return APISession(config=config, proxy_mode=True)
 
 
-async def get_anonymous_session(request: web.Request) -> APISession:
+async def get_anonymous_session(
+    request: web.Request,
+    api_endpoint: str = None,
+) -> APISession:
     config = request.app['config']
+    if api_endpoint is not None:
+        config = copy.deepcopy(config)
+        config['api']['endpoint'] = api_endpoint
     config = APIConfig(
         domain=config['api']['domain'],
         endpoint=config['api']['endpoint'],

--- a/src/ai/backend/console/proxy.py
+++ b/src/ai/backend/console/proxy.py
@@ -246,11 +246,13 @@ async def websocket_handler(request, *, is_anonymous=False) -> web.StreamRespons
     # Choose a specific Manager endpoint for persistent web app connection.
     api_endpoint = None
     should_save_session = False
+    _endpoints = request.app['config']['api']['endpoint'].split(',')
+    _endpoints = [e.strip() for e in _endpoints]
     if session.get('api_endpoints', {}).get(app):
-        api_endpoint = session['api_endpoints'][app]
-    else:
-        _endpoints = request.app['config']['api']['endpoint']
-        api_endpoint = random.choice(_endpoints.split(',')).strip()
+        if session['api_endpoints'][app] in _endpoints:
+            api_endpoint = session['api_endpoints'][app]
+    if api_endpoint is None:
+        api_endpoint = random.choice(_endpoints)
         if 'api_endpoints' not in session:
             session['api_endpoints'] = {}
         session['api_endpoints'][app] = api_endpoint

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -83,3 +83,17 @@ async def test_get_anonymous_session(mocker):
         assert str(api_session.config.endpoint) == 'https://api.backend.ai'
         assert api_session.config.access_key == ''
         assert api_session.config.secret_key == ''
+
+
+@pytest.mark.asyncio
+async def test_get_anonymous_session_with_specific_api_endpoint(mocker):
+    mock_request = DummyRequest({'config': {
+        'api': {'domain': 'default', 'endpoint': 'https://api.backend.ai'},
+    }})
+    specific_api_endpoint = 'https://alternative.backend.ai'
+    mock_get_session = MagicMock()
+    mocker.patch('ai.backend.console.auth.get_session', mock_get_session)
+    api_session = await get_anonymous_session(mock_request, specific_api_endpoint)
+    mock_get_session.assert_not_called()
+    async with api_session:
+        assert str(api_session.config.endpoint) == specific_api_endpoint

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -52,6 +52,23 @@ async def test_get_api_session(mocker):
 
 
 @pytest.mark.asyncio
+async def test_get_api_session_with_specific_api_endpoint(mocker):
+    mock_request = DummyRequest({'config': {
+        'api': {'domain': 'default', 'endpoint': 'https://api.backend.ai'},
+    }})
+    mock_get_session = AsyncMock(return_value={
+        'authenticated': True,
+        'token': {'type': 'keypair', 'access_key': 'ABC', 'secret_key': 'xyz'},
+    })
+    specific_api_endpoint = 'https://alternative.backend.ai'
+    mocker.patch('ai.backend.console.auth.get_session', mock_get_session)
+    api_session = await get_api_session(mock_request, specific_api_endpoint)
+    mock_get_session.assert_awaited_once()
+    async with api_session:
+        assert str(api_session.config.endpoint) == specific_api_endpoint
+
+
+@pytest.mark.asyncio
 async def test_get_anonymous_session(mocker):
     mock_request = DummyRequest({'config': {
         'api': {'domain': 'default', 'endpoint': 'https://api.backend.ai'},


### PR DESCRIPTION
Under HA Manager configuration, websocket requests for each app need to be delivered to a specific Manager. For example, when the ttyd app is launched, the first connected Manager relays the websocket connection between the WSProxy and the container service, so the subsequent requests from the ttyd should be delivered to THE first Manager.

This PR delivers websocket streaming requests for each session and each app to only a specific Manager.
* At the first access, randomly select a Manager endpoint and store it in the browser session with the app name as a key, for example, in `session['api_endpoints']['ttyd'] = <manager-endpoint>`.
* When processing subsequent websocket requests, query the endpoint of the app from the browser session, and if there exists, send API request using the endpoint.

aiohttp_session [Does not automatically save browser session information in its middleware for StreamResponse](https://github.com/aio-libs/aiohttp-session/blob/master/aiohttp_session/__init__.py#L160-L162). Therefore, if necessary, the browser session was saved manually in websocket requests.